### PR TITLE
didi-cloud is blocked due to their cert

### DIFF
--- a/sudoTmdb/utils.py
+++ b/sudoTmdb/utils.py
@@ -231,8 +231,7 @@ async def build_tvshow_embed(ctx, data, tv_id, i, results):
         "Watch": "\n".join([
             f"[pseudo-flix](https://pseudo-flix.pro/media/tmdb-tv-{tv_id})",
             f"[levrx](https://movies.levrx.de/media/tmdb-tv-{tv_id})",
-            f"[pstream ⭐](https:/pstream.org/media/tmdb-tv-{tv_id})",
-            f"[didi-flix](https://movies.didiinthe.cloud/media/tmdb-tv-{tv_id})",
+            f"[pstream ⭐](https:/pstream.org/media/tmdb-tv-{tv_id})"
         ])
     }
     total_length = len(embed.title) + len(embed.description)
@@ -305,8 +304,7 @@ async def build_movie_embed(ctx, data, movie_id, i, results):
         "Watch": "\n".join([
             f"[pseudo-flix](https://pseudo-flix.pro/media/tmdb-movie-{movie_id})",
             f"[movies.levrx](https://movies.levrx.de/media/tmdb-movie-{movie_id})",
-            f"[pstream ⭐](https:/pstream.org/media/tmdb-movie-{movie_id})",
-            f"[didi-flix](https://movies.didiinthe.cloud/media/tmdb-movie-{movie_id})",
+            f"[pstream ⭐](https:/pstream.org/media/tmdb-movie-{movie_id})"
         ])
     }
     total_length = len(embed.title) + len(embed.description)


### PR DESCRIPTION
https://movies.didiinthe.cloud/ is blocked due to their invalid cert that expired and hasn't updated.

request to remove it until they fix it.